### PR TITLE
CFY-4805 check inputs against the schema, not just for null values

### DIFF
--- a/dsl_parser/interfaces/utils.py
+++ b/dsl_parser/interfaces/utils.py
@@ -19,16 +19,24 @@ from dsl_parser import (functions,
 from dsl_parser.exceptions import DSLParsingLogicException
 
 
-def validate_missing_inputs(inputs):
-    for key, value in inputs.iteritems():
-        if value is None:
-            raise DSLParsingLogicException(
-                107,
-                "Input '{0}' is missing a value".format(key))
+def validate_missing_inputs(inputs, schema_inputs):
+    """Check that all inputs defined in schema_inputs exist in inputs"""
+
+    missing_inputs = set(schema_inputs) - set(inputs)
+    if missing_inputs:
+        if len(missing_inputs) == 1:
+            message = "Input '{0}' is missing a value".format(
+                missing_inputs.pop())
+        else:
+            formatted_inputs = ', '.join("'{0}'".format(input_name)
+                                         for input_name in missing_inputs)
+            message = "Inputs {0} are missing a value".format(formatted_inputs)
+
+        raise DSLParsingLogicException(107, message)
 
 
-def validate_inputs_types(inputs, inputs_schema):
-    for input_key, _input in inputs_schema.iteritems():
+def validate_inputs_types(inputs, schema_inputs):
+    for input_key, _input in schema_inputs.iteritems():
         input_type = _input.get('type')
         if input_type is None:
             # no type defined - no validation
@@ -72,7 +80,7 @@ def merge_schema_and_instance_inputs(schema_inputs,
         flattened_schema_inputs.items() +
         instance_inputs.items())
 
-    validate_missing_inputs(merged_inputs)
+    validate_missing_inputs(merged_inputs, schema_inputs)
     validate_inputs_types(merged_inputs, schema_inputs)
     return merged_inputs
 

--- a/dsl_parser/tests/test_inputs.py
+++ b/dsl_parser/tests/test_inputs.py
@@ -14,7 +14,8 @@
 #    * limitations under the License.
 
 from dsl_parser.tasks import prepare_deployment_plan
-from dsl_parser.exceptions import MissingRequiredInputError, UnknownInputError
+from dsl_parser.exceptions import (MissingRequiredInputError,
+                                   UnknownInputError, DSLParsingLogicException)
 from dsl_parser.tests.abstract_test_parser import AbstractTestParser
 
 
@@ -405,3 +406,52 @@ outputs:
         prepared = prepare_deployment_plan(self.parse(yaml))
         outputs = prepared.outputs
         self.assertEqual(8080, outputs['a']['value'])
+
+    def test_missing_input_exception(self):
+        yaml = """
+node_types:
+  type:
+    interfaces:
+      interface:
+        op:
+          implementation: plugin.mapping
+          inputs:
+            some_input:
+              type: string
+node_templates:
+  node:
+    type: type
+plugins:
+  plugin:
+    install: false
+    executor: central_deployment_agent
+"""
+        ex = self._assert_dsl_parsing_exception_error_code(
+            yaml, 107, DSLParsingLogicException)
+        self.assertIn('some_input', ex.message)
+
+    def test_missing_inputs_both_reported(self):
+        yaml = """
+node_types:
+  type:
+    interfaces:
+      interface:
+        op:
+          implementation: plugin.mapping
+          inputs:
+            some_input:
+              type: string
+            another_input:
+              type: string
+node_templates:
+  node:
+    type: type
+plugins:
+  plugin:
+    install: false
+    executor: central_deployment_agent
+"""
+        ex = self._assert_dsl_parsing_exception_error_code(
+            yaml, 107, DSLParsingLogicException)
+        self.assertIn('some_input', ex.message)
+        self.assertIn('another_input', ex.message)


### PR DESCRIPTION
dsl_parser.interfaces.utils.validate_missing_inputs used to assume that an input is missing if its value is None - this worked because dsl_parser.utils.flatten_schema used to set a None default value if there was no other default.

It was later changed to only set a default if there is a default - inputs without any value were omitted entirely, which makes validate_missing_inputs need to check for omitted inputs, not just look for None