### PR TITLE
Make dsl-parser not depend on dict ordering

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,10 +11,10 @@ dependencies:
   pre:
     - pyenv local 2.7.9 2.6.8
   override:
-    - pip install tox==1.6.1
+    - pip install tox==1.7.0
 test:
   override:
-    - case $CIRCLE_NODE_INDEX in 0) tox -e py27 ;; 1) tox -e py26 ;; esac:
+    - for i in {1..5}; do case $CIRCLE_NODE_INDEX in 0) tox -e py27 ;; 1) tox -e py26 ;; esac; done:
         parallel: true
     - case $CIRCLE_NODE_INDEX in 0) tox -e flake8 ;; esac:
         parallel: true

--- a/dsl_parser/elements/workflows.py
+++ b/dsl_parser/elements/workflows.py
@@ -71,7 +71,7 @@ class Workflows(DictElement):
     def calculate_provided(self, plugins):
         workflow_plugins = []
         workflow_plugin_names = set()
-        for workflow, op_struct in self.value.items():
+        for workflow, op_struct in sorted(self.value.items()):
             if op_struct['plugin'] not in workflow_plugin_names:
                 plugin_name = op_struct['plugin']
                 workflow_plugins.append(plugins[plugin_name])

--- a/dsl_parser/scan.py
+++ b/dsl_parser/scan.py
@@ -90,7 +90,9 @@ def _scan_operations(operations,
                      context=None,
                      path='',
                      replace=False):
-    for name, definition in operations.iteritems():
+    for name, definition in sorted(operations.items(),
+                                   key=lambda (k, v): k.count('.'),
+                                   reverse=True):
         if isinstance(definition, dict) and 'inputs' in definition:
             context = context.copy() if context else {}
             context['operation'] = definition

--- a/dsl_parser/scan.py
+++ b/dsl_parser/scan.py
@@ -51,7 +51,7 @@ def scan_properties(value,
     :param path: The properties base path (for debugging purposes).
     """
     if isinstance(value, dict):
-        for k, v in value.iteritems():
+        for k, v in sorted(value.iteritems()):
             current_path = '{0}.{1}'.format(path, k)
             result = handler(v, scope, context, current_path)
             _collect_secret(result)

--- a/dsl_parser/tasks.py
+++ b/dsl_parser/tasks.py
@@ -96,7 +96,7 @@ def _validate_secrets(plan, get_secret_method):
         )
 
     invalid_secrets = []
-    for secret_key in plan['secrets']:
+    for secret_key in sorted(plan['secrets']):
         try:
             get_secret_method(secret_key)
         except Exception as exception:

--- a/dsl_parser/tests/test_functions.py
+++ b/dsl_parser/tests/test_functions.py
@@ -765,6 +765,40 @@ node_templates:
         self.assertEqual('secret', plan['nodes'][0]['properties']['b'])
 
     @timeout(seconds=10)
+    def test_edliu_example(self):
+        yaml = """
+inputs:
+    dict_input: {}
+
+node_types:
+    pgaasdb:
+        properties:
+            user: {}
+    other:
+        properties:
+            a: { type: string }
+
+node_templates:
+    pgaasdb:
+        type: pgaasdb
+        properties:
+            user: { get_input: dict_input}
+    other:
+        type: other
+        properties:
+            a: { get_property: [pgaasdb, user, user] }
+"""
+        p = self.parse(yaml)
+        plan = prepare_deployment_plan(
+            p, inputs={'dict_input': {'user': 'abc'}})
+        for node in plan['nodes']:
+            if 'a' in node['properties']:
+                self.assertEqual('abc', node['properties']['a'])
+                break
+        else:
+            self.fail('Node with attribute "a" not found')
+
+    @timeout(seconds=10)
     def test_get_property_from_get_input_data_type(self):
         yaml = """
 inputs:

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -194,10 +194,11 @@ node_templates:
         expected_message = "Required secrets \['ip', 'source_op_secret_id'\]" \
                            " don't exist in this tenant"
 
-        get_secret_not_found = MagicMock()
-        get_secret_not_found.side_effect = [None, None, TestNotFoundException,
-                                            None, None, None,
-                                            TestNotFoundException]
+        def _mock_get_secret(secret):
+            if secret in ('ip', 'source_op_secret_id'):
+                raise TestNotFoundException
+
+        get_secret_not_found = MagicMock(side_effect=_mock_get_secret)
         self.assertRaisesRegexp(exceptions.UnknownSecretError,
                                 expected_message,
                                 prepare_deployment_plan,

--- a/dsl_parser/tests/test_get_secret.py
+++ b/dsl_parser/tests/test_get_secret.py
@@ -170,11 +170,11 @@ node_templates:
         self.assertFalse(hasattr(parsed, 'secrets'))
 
     def test_validate_secrets_all_invalid(self):
-        expected_message = "Required secrets \['target_op_secret_id', " \
-                           "'node_template_secret_id', 'ip', 'agent_key', " \
-                           "'user', 'webserver_port', " \
-                           "'source_op_secret_id'\] don't exist in this tenant"
-
+        expected_message = "Required secrets \['agent_key', " \
+                           "'ip', 'node_template_secret_id', " \
+                           "'source_op_secret_id', 'target_op_secret_id', " \
+                           "'user', 'webserver_port'\] don't exist "\
+                           "in this tenant"
         get_secret_not_found = MagicMock(side_effect=TestNotFoundException)
         self.assertRaisesRegexp(exceptions.UnknownSecretError,
                                 expected_message,


### PR DESCRIPTION
With these changes, all tests pass with random hash seeds.

Of course there are still many places that do iterate over dicts
where we don't use `sorted()` etc., but since none of the tests
checks those, they're considered OK no matter what's the
ordering of the iteration.

Thus, not every .iteritems/.iterkeys/etc call was wrapped with sorted(),
just those that we check in tests.